### PR TITLE
fix/session-ownership

### DIFF
--- a/mcpServer.js
+++ b/mcpServer.js
@@ -300,7 +300,10 @@ async function run() {
             profile: userInfo
           };
 
-          // Fetch Repliers API key from PropelAuth org metadata
+          // Fetch Repliers API key from PropelAuth org metadata. Tracked separately from a
+          // missing key: "we could not ask" and "the account has no key" are different
+          // failures and land on different people.
+          let keyLookupFailed = false;
           if (req.user.id && process.env.PROPELAUTH_API_KEY) {
             try {
               // UserInfo endpoint doesn't include org membership — fetch it from the backend user API
@@ -313,13 +316,36 @@ async function run() {
                 req.user.repliersApiKey = userData.metadata?.repliers_api_key;
                 console.error(`[DEBUG] Repliers API key ${req.user.repliersApiKey ? 'found' : 'not found'} in user metadata`);
               } else {
+                keyLookupFailed = true;
                 console.error(`[WARN] Could not fetch user from PropelAuth backend: ${userResponse.status}`);
               }
             } catch (orgError) {
+              keyLookupFailed = true;
               console.error('[WARN] Error fetching org metadata:', orgError.message);
             }
           } else {
+            keyLookupFailed = true;
             if (!process.env.PROPELAUTH_API_KEY) console.error('[DEBUG] PROPELAUTH_API_KEY not set, skipping org metadata fetch');
+          }
+
+          // Hosted mode has no fallback key. Without one, every tool call would still be
+          // served, ship the literal string "undefined" as REPLIERS-API-KEY and come back as
+          // a Repliers 401 — turning our own misconfiguration into what looks like their
+          // outage, several layers away from the cause. Refuse here instead, and distinguish
+          // the two cases so the log says who has to fix it.
+          if (!req.user.repliersApiKey) {
+            if (keyLookupFailed) {
+              console.error(`[ERROR] Refusing ${req.user.id}: could not read the Repliers key from PropelAuth`);
+              return res.status(503).json({
+                error: "key_lookup_failed",
+                message: "Could not read this account's Repliers API key from PropelAuth. This is a server-side configuration problem, not a problem with the request."
+              });
+            }
+            console.error(`[ERROR] Refusing ${req.user.id}: no repliers_api_key in PropelAuth metadata`);
+            return res.status(403).json({
+              error: "account_not_provisioned",
+              message: "This account has no Repliers API key configured. Contact Repliers support to have it enabled for MCP access."
+            });
           }
 
           // Handed to the transport per request: the SDK surfaces req.auth to every request

--- a/mcpServer.js
+++ b/mcpServer.js
@@ -132,7 +132,7 @@ async function transformTools(tools) {
     .filter(Boolean);
 }
 
-async function setupServerHandlers(server, tools, repliersApiKey) {
+async function setupServerHandlers(server, tools) {
   console.error("[DEBUG] Setting up server handlers");
 
   // List tools handler
@@ -140,8 +140,8 @@ async function setupServerHandlers(server, tools, repliersApiKey) {
     tools: await transformTools(tools),
   }));
 
-  // Call tool handler - FIXED VERSION
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  // Call tool handler
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const toolName = request.params.name;
     console.error(`[DEBUG] Tool call requested: ${toolName}`);
 
@@ -165,6 +165,14 @@ async function setupServerHandlers(server, tools, repliersApiKey) {
         );
       }
     }
+
+    // The Repliers key is resolved per request, from the identity verifyOAuthToken proved
+    // for this very call, rather than captured when the session was opened. A key that is
+    // rotated or revoked upstream therefore takes effect on the next call instead of living
+    // on for the lifetime of the session. Absent in self-hosted and stdio mode, where there
+    // is no per-user identity and the environment key is the only one.
+    const repliersApiKey =
+      extra?.authInfo?.extra?.repliersApiKey ?? process.env.REPLIERS_API_KEY;
 
     try {
       const result = await tool.function({ ...args, _repliersApiKey: repliersApiKey });
@@ -314,6 +322,15 @@ async function run() {
             if (!process.env.PROPELAUTH_API_KEY) console.error('[DEBUG] PROPELAUTH_API_KEY not set, skipping org metadata fetch');
           }
 
+          // Handed to the transport per request: the SDK surfaces req.auth to every request
+          // handler as extra.authInfo, which is how the tool call gets the caller's key.
+          req.auth = {
+            token,
+            clientId: process.env.OAUTH_CLIENT_ID || 'unknown',
+            scopes: [],
+            extra: { userId: req.user.id, repliersApiKey: req.user.repliersApiKey },
+          };
+
           console.error(`[DEBUG] User authenticated: ${req.user.id} (${req.user.email || 'no email'})`);
           next();
 
@@ -447,7 +464,6 @@ async function run() {
             return res.status(400).json({ error: "New sessions must be initialized with a POST request" });
           }
 
-          const repliersApiKey = selfHosted ? process.env.REPLIERS_API_KEY : req.user.repliersApiKey;
           const sessionUserId = selfHosted ? null : req.user.id;
           console.error(`[DEBUG] New MCP session${selfHosted ? '' : ` for user: ${sessionUserId}`}`);
 
@@ -458,7 +474,7 @@ async function run() {
           server.onerror = (error) => console.error("[SERVER ERROR]", error);
 
           const tools = await discoverTools();
-          await setupServerHandlers(server, tools, repliersApiKey);
+          await setupServerHandlers(server, tools);
 
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),

--- a/mcpServer.js
+++ b/mcpServer.js
@@ -241,7 +241,7 @@ async function run() {
       const app = express();
       app.use(express.json());
 
-      const sessions = {}; // sessionId -> { transport, server }
+      const sessions = {}; // sessionId -> { transport, server, userId }
 
       // OAuth token verification middleware using UserInfo endpoint
       async function verifyOAuthToken(req, res, next) {
@@ -422,10 +422,20 @@ async function run() {
         try {
           const sessionId = req.headers['mcp-session-id'];
 
-          // Route existing sessions directly
+          // Route existing sessions directly. A session id is a client-supplied
+          // header, so it never stands in for identity: the caller proven by
+          // verifyOAuthToken must also be the user the session was opened for,
+          // otherwise any authenticated user could drive another user's session
+          // and spend their Repliers API key. Mismatches answer 404 rather than
+          // 403 so the endpoint cannot be used to probe which session ids exist.
           if (sessionId) {
             const session = sessions[sessionId];
-            if (!session) {
+            if (!session || (!selfHosted && session.userId !== req.user.id)) {
+              if (session) {
+                console.error(
+                  `[WARN] Session ownership mismatch: ${sessionId} is owned by ${session.userId}, requested by ${req.user.id}`
+                );
+              }
               return res.status(404).json({ error: "Session not found" });
             }
             await session.transport.handleRequest(req, res, req.body);
@@ -438,7 +448,8 @@ async function run() {
           }
 
           const repliersApiKey = selfHosted ? process.env.REPLIERS_API_KEY : req.user.repliersApiKey;
-          console.error(`[DEBUG] New MCP session${selfHosted ? '' : ` for user: ${req.user.id}`}`);
+          const sessionUserId = selfHosted ? null : req.user.id;
+          console.error(`[DEBUG] New MCP session${selfHosted ? '' : ` for user: ${sessionUserId}`}`);
 
           const server = new Server(
             { name: SERVER_NAME, version: "0.1.0" },
@@ -452,8 +463,8 @@ async function run() {
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sid) => {
-              sessions[sid] = { transport, server };
-              console.error(`[DEBUG] Session initialized: ${sid}`);
+              sessions[sid] = { transport, server, userId: sessionUserId };
+              console.error(`[DEBUG] Session initialized: ${sid}${selfHosted ? '' : ` (owner: ${sessionUserId})`}`);
             },
             onsessionclosed: (sid) => {
               delete sessions[sid];

--- a/test/helpers/hostedMcpServer.js
+++ b/test/helpers/hostedMcpServer.js
@@ -1,0 +1,197 @@
+// Shared harness for the hosted-mode HTTP tests: a stub PropelAuth, a stub Repliers API and
+// a real `node mcpServer.js --http` child. Lives outside the *.test.js glob so npm test
+// does not try to run it as a suite.
+import http from "node:http";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Two tenants of the same PropelAuth instance, each with their own Repliers key. */
+export function defaultUsers() {
+  return {
+    "alice-token": { sub: "user-alice", email: "alice@example.test", key: "KEY-ALICE-1" },
+    "bob-token": { sub: "user-bob", email: "bob@example.test", key: "KEY-BOB-1" },
+  };
+}
+
+/**
+ * Stands in for PropelAuth: /oauth/userinfo plus the backend user API that mcpServer.js
+ * reads repliers_api_key from. Serves `users` live, so rotateKey() is visible to the very
+ * next request the server makes.
+ */
+export async function startFakePropelAuth(users = defaultUsers()) {
+  const server = http.createServer((req, res) => {
+    const bearer = (req.headers.authorization || "").replace(/^Bearer /, "");
+    const url = new URL(req.url, "http://localhost");
+
+    if (url.pathname === "/oauth/userinfo") {
+      const user = users[bearer];
+      if (!user) return res.writeHead(401).end("{}");
+      return res
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ sub: user.sub, email: user.email, email_verified: true }));
+    }
+
+    const backend = url.pathname.match(/^\/api\/backend\/v1\/user\/(.+)$/);
+    if (backend) {
+      const user = Object.values(users).find((u) => u.sub === backend[1]);
+      if (!user) return res.writeHead(404).end("{}");
+      return res
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ metadata: { repliers_api_key: user.key } }));
+    }
+
+    res.writeHead(404).end("{}");
+  });
+
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  return {
+    port: server.address().port,
+    users,
+    rotateKey(sub, key) {
+      const user = Object.values(users).find((u) => u.sub === sub);
+      assert.ok(user, `no such fake user: ${sub}`);
+      user.key = key;
+    },
+    close: () => new Promise((r) => server.close(r)),
+  };
+}
+
+/** Stands in for api.repliers.io, recording the REPLIERS-API-KEY each tool call arrives with. */
+export async function startFakeRepliersApi() {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    const key = req.headers["repliers-api-key"] ?? null;
+    received.push({ key, url: req.url });
+    res
+      .writeHead(200, { "content-type": "application/json" })
+      .end(JSON.stringify({ receivedKey: key }));
+  });
+
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  return {
+    port: server.address().port,
+    received,
+    lastKey: () => received.at(-1)?.key,
+    close: () => new Promise((r) => server.close(r)),
+  };
+}
+
+function freePort() {
+  return new Promise((resolve) => {
+    const probe = http.createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Boots the real mcpServer.js in hosted mode.
+ * The empty REPLIERS_API_KEY matters: process.loadEnvFile never overrides an already-set
+ * variable, so it keeps the repo's own .env from flipping the server into self-hosted mode
+ * (which would drop verifyOAuthToken from the chain entirely). Same trick pins the API host.
+ */
+export async function startMcpServer({ propelAuthPort, repliersApiPort }) {
+  const port = await freePort();
+  const oauthBase = `http://127.0.0.1:${propelAuthPort}`;
+  const child = spawn(process.execPath, ["mcpServer.js", "--http"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      REPLIERS_API_KEY: "",
+      REPLIERS_API_BASE_URL: repliersApiPort ? `http://127.0.0.1:${repliersApiPort}` : "",
+      PORT: String(port),
+      OAUTH_BASE_URL: oauthBase,
+      OAUTH_USERINFO_ENDPOINT: `${oauthBase}/oauth/userinfo`,
+      PROPELAUTH_API_KEY: "propelauth-test-key",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let log = "";
+  child.stdout.on("data", (d) => (log += d));
+  child.stderr.on("data", (d) => (log += d));
+
+  const deadline = Date.now() + 20000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`server exited early:\n${log}`);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      if (res.ok) {
+        const body = await res.json();
+        assert.equal(body.oauth_enabled, true, `server must be in hosted mode:\n${log}`);
+        break;
+      }
+    } catch {
+      /* not listening yet */
+    }
+    if (Date.now() > deadline) throw new Error(`server never became ready:\n${log}`);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  return { port, child, log: () => log, close: () => child.kill() };
+}
+
+export function mcpFetch(port, { token, sessionId, body, method = "POST" }) {
+  const headers = {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return fetch(`http://127.0.0.1:${port}/mcp`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+export const INITIALIZE = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "hosted-harness", version: "1.0.0" },
+  },
+};
+
+/** Runs initialize + notifications/initialized and returns the issued session id. */
+export async function openSession(port, token) {
+  const res = await mcpFetch(port, { token, body: INITIALIZE });
+  const text = await res.text(); // drain the SSE stream so the connection is released
+  assert.equal(res.status, 200, `initialize failed: ${text}`);
+  const sessionId = res.headers.get("mcp-session-id");
+  assert.ok(sessionId, "server did not issue an mcp-session-id");
+
+  const ack = await mcpFetch(port, {
+    token,
+    sessionId,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+  await ack.text();
+  return sessionId;
+}
+
+let nextId = 100;
+
+/** Issues a tools/call and returns { status, text }. */
+export async function callTool(port, { token, sessionId, name, args = {} }) {
+  const res = await mcpFetch(port, {
+    token,
+    sessionId,
+    body: {
+      jsonrpc: "2.0",
+      id: nextId++,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+  });
+  return { status: res.status, text: await res.text() };
+}

--- a/test/helpers/hostedMcpServer.js
+++ b/test/helpers/hostedMcpServer.js
@@ -14,6 +14,8 @@ export function defaultUsers() {
   return {
     "alice-token": { sub: "user-alice", email: "alice@example.test", key: "KEY-ALICE-1" },
     "bob-token": { sub: "user-bob", email: "bob@example.test", key: "KEY-BOB-1" },
+    // Authenticates fine, but was never provisioned with a Repliers key.
+    "keyless-token": { sub: "user-keyless", email: "keyless@example.test", key: null },
   };
 }
 
@@ -23,6 +25,7 @@ export function defaultUsers() {
  * next request the server makes.
  */
 export async function startFakePropelAuth(users = defaultUsers()) {
+  const state = { rejectBackend: false };
   const server = http.createServer((req, res) => {
     const bearer = (req.headers.authorization || "").replace(/^Bearer /, "");
     const url = new URL(req.url, "http://localhost");
@@ -37,11 +40,18 @@ export async function startFakePropelAuth(users = defaultUsers()) {
 
     const backend = url.pathname.match(/^\/api\/backend\/v1\/user\/(.+)$/);
     if (backend) {
+      // Simulates our own PROPELAUTH_API_KEY being wrong or expired.
+      if (state.rejectBackend) {
+        return res
+          .writeHead(401, { "content-type": "application/json" })
+          .end(JSON.stringify({ error: "invalid_api_key" }));
+      }
       const user = Object.values(users).find((u) => u.sub === backend[1]);
       if (!user) return res.writeHead(404).end("{}");
+      const metadata = user.key === null ? {} : { repliers_api_key: user.key };
       return res
         .writeHead(200, { "content-type": "application/json" })
-        .end(JSON.stringify({ metadata: { repliers_api_key: user.key } }));
+        .end(JSON.stringify({ metadata }));
     }
 
     res.writeHead(404).end("{}");
@@ -51,6 +61,10 @@ export async function startFakePropelAuth(users = defaultUsers()) {
   return {
     port: server.address().port,
     users,
+    /** Makes the backend user API reject our PROPELAUTH_API_KEY, as a wrong one would. */
+    setBackendRejects(value) {
+      state.rejectBackend = value;
+    },
     rotateKey(sub, key) {
       const user = Object.values(users).find((u) => u.sub === sub);
       assert.ok(user, `no such fake user: ${sub}`);

--- a/test/httpKeyProvisioning.test.js
+++ b/test/httpKeyProvisioning.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  startFakePropelAuth,
+  startFakeRepliersApi,
+  startMcpServer,
+  mcpFetch,
+  openSession,
+  callTool,
+  INITIALIZE,
+} from "./helpers/hostedMcpServer.js";
+
+const TOOL = { name: "autocomplete-location-search", args: { search: "tor" } };
+
+test("hosted mode refuses to open a session it cannot serve", async (t) => {
+  const propelAuth = await startFakePropelAuth();
+  const repliers = await startFakeRepliersApi();
+  const mcp = await startMcpServer({
+    propelAuthPort: propelAuth.port,
+    repliersApiPort: repliers.port,
+  });
+
+  t.after(async () => {
+    mcp.close();
+    await Promise.all([propelAuth.close(), repliers.close()]);
+  });
+
+  const { port } = mcp;
+
+  await t.test("a user with no Repliers key in their metadata gets no session", async () => {
+    const res = await mcpFetch(port, { token: "keyless-token", body: INITIALIZE });
+    const text = await res.text();
+
+    assert.equal(
+      res.status,
+      403,
+      `an unprovisioned user was handed a working session: ${text}`
+    );
+    assert.equal(
+      res.headers.get("mcp-session-id"),
+      null,
+      "a session id was issued for a caller whose tool calls cannot be served"
+    );
+    assert.equal(repliers.received.length, 0, "nothing should have reached the API");
+  });
+
+  await t.test("our own PropelAuth key being rejected fails loudly, not silently", async () => {
+    propelAuth.setBackendRejects(true);
+
+    const res = await mcpFetch(port, { token: "alice-token", body: INITIALIZE });
+    const text = await res.text();
+
+    assert.equal(
+      res.status,
+      503,
+      `a server-side misconfiguration was served as a working session: ${text}`
+    );
+    assert.equal(res.headers.get("mcp-session-id"), null, "a session id was issued anyway");
+    assert.equal(repliers.received.length, 0, "nothing should have reached the API");
+  });
+
+  await t.test("a provisioned user is unaffected once the backend recovers", async () => {
+    propelAuth.setBackendRejects(false);
+
+    const session = await openSession(port, "alice-token");
+    const { status } = await callTool(port, { token: "alice-token", sessionId: session, ...TOOL });
+
+    assert.equal(status, 200);
+    assert.equal(repliers.lastKey(), "KEY-ALICE-1", "the provisioned key stopped flowing");
+  });
+
+  await t.test("a key that disappears mid-session stops the session, not the API", async () => {
+    const session = await openSession(port, "alice-token");
+    propelAuth.rotateKey("user-alice", null);
+
+    const before = repliers.received.length;
+    const res = await mcpFetch(port, {
+      token: "alice-token",
+      sessionId: session,
+      body: { jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: TOOL.name, arguments: TOOL.args } },
+    });
+    await res.text();
+
+    assert.equal(res.status, 403, "a deprovisioned caller kept being served");
+    assert.equal(
+      repliers.received.length,
+      before,
+      "the tool still called the API, which would arrive as REPLIERS-API-KEY: undefined"
+    );
+  });
+});

--- a/test/httpPerRequestApiKey.test.js
+++ b/test/httpPerRequestApiKey.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  startFakePropelAuth,
+  startFakeRepliersApi,
+  startMcpServer,
+  openSession,
+  callTool,
+} from "./helpers/hostedMcpServer.js";
+
+const TOOL = { name: "autocomplete-location-search", args: { search: "tor" } };
+
+test("hosted mode resolves the Repliers key per request, not per session", async (t) => {
+  const propelAuth = await startFakePropelAuth();
+  const repliers = await startFakeRepliersApi();
+  const mcp = await startMcpServer({
+    propelAuthPort: propelAuth.port,
+    repliersApiPort: repliers.port,
+  });
+
+  t.after(async () => {
+    mcp.close();
+    await Promise.all([propelAuth.close(), repliers.close()]);
+  });
+
+  const { port } = mcp;
+  const aliceSession = await openSession(port, "alice-token");
+
+  await t.test("a tool call reaches the API with the caller's own key", async () => {
+    const { status, text } = await callTool(port, {
+      token: "alice-token",
+      sessionId: aliceSession,
+      ...TOOL,
+    });
+    assert.equal(status, 200, text);
+    assert.match(text, /receivedKey/, `tool never reached the stub API: ${text}`);
+    assert.equal(repliers.lastKey(), "KEY-ALICE-1");
+  });
+
+  await t.test("a key rotated mid-session takes effect on the next call", async () => {
+    // The operator revokes Alice's key and issues a new one. Nothing about her MCP session
+    // changes — same session id, same transport, same server instance.
+    propelAuth.rotateKey("user-alice", "KEY-ALICE-2");
+
+    const { status, text } = await callTool(port, {
+      token: "alice-token",
+      sessionId: aliceSession,
+      ...TOOL,
+    });
+    assert.equal(status, 200, text);
+    assert.equal(
+      repliers.lastKey(),
+      "KEY-ALICE-2",
+      "the session kept serving the key captured when it was opened, so a revoked key stays live"
+    );
+  });
+
+  await t.test("each session's calls carry that session owner's key", async () => {
+    const bobSession = await openSession(port, "bob-token");
+
+    await callTool(port, { token: "bob-token", sessionId: bobSession, ...TOOL });
+    assert.equal(repliers.lastKey(), "KEY-BOB-1");
+
+    await callTool(port, { token: "alice-token", sessionId: aliceSession, ...TOOL });
+    assert.equal(repliers.lastKey(), "KEY-ALICE-2");
+  });
+});

--- a/test/httpSessionOwnership.test.js
+++ b/test/httpSessionOwnership.test.js
@@ -1,151 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import http from "node:http";
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-
-// Two tenants of the same PropelAuth instance, each with their own Repliers key.
-const USERS = {
-  "alice-token": { sub: "user-alice", email: "alice@example.test", key: "KEY-ALICE" },
-  "bob-token": { sub: "user-bob", email: "bob@example.test", key: "KEY-BOB" },
-};
-
-/** Stand-in for PropelAuth: /oauth/userinfo + the backend user API mcpServer.js reads metadata from. */
-function startFakePropelAuth() {
-  const server = http.createServer((req, res) => {
-    const bearer = (req.headers.authorization || "").replace(/^Bearer /, "");
-    const url = new URL(req.url, "http://localhost");
-
-    if (url.pathname === "/oauth/userinfo") {
-      const user = USERS[bearer];
-      if (!user) return res.writeHead(401).end("{}");
-      return res
-        .writeHead(200, { "content-type": "application/json" })
-        .end(JSON.stringify({ sub: user.sub, email: user.email, email_verified: true }));
-    }
-
-    const backend = url.pathname.match(/^\/api\/backend\/v1\/user\/(.+)$/);
-    if (backend) {
-      const user = Object.values(USERS).find((u) => u.sub === backend[1]);
-      if (!user) return res.writeHead(404).end("{}");
-      return res
-        .writeHead(200, { "content-type": "application/json" })
-        .end(JSON.stringify({ metadata: { repliers_api_key: user.key } }));
-    }
-
-    res.writeHead(404).end("{}");
-  });
-  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
-}
-
-function freePort() {
-  return new Promise((resolve) => {
-    const probe = http.createServer();
-    probe.listen(0, "127.0.0.1", () => {
-      const { port } = probe.address();
-      probe.close(() => resolve(port));
-    });
-  });
-}
-
-/**
- * Boots the real mcpServer.js in hosted mode.
- * REPLIERS_API_KEY='' matters: process.loadEnvFile never overrides an already-set
- * variable, so the empty string keeps the repo's own .env from flipping the server
- * into self-hosted mode (which would bypass verifyOAuthToken entirely).
- */
-async function startMcpServer(propelAuthPort) {
-  const port = await freePort();
-  const oauthBase = `http://127.0.0.1:${propelAuthPort}`;
-  const child = spawn(process.execPath, ["mcpServer.js", "--http"], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      REPLIERS_API_KEY: "",
-      PORT: String(port),
-      OAUTH_BASE_URL: oauthBase,
-      OAUTH_USERINFO_ENDPOINT: `${oauthBase}/oauth/userinfo`,
-      PROPELAUTH_API_KEY: "propelauth-test-key",
-    },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  let log = "";
-  child.stdout.on("data", (d) => (log += d));
-  child.stderr.on("data", (d) => (log += d));
-
-  const deadline = Date.now() + 20000;
-  for (;;) {
-    if (child.exitCode !== null) throw new Error(`server exited early:\n${log}`);
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/health`);
-      if (res.ok) {
-        const body = await res.json();
-        assert.equal(body.oauth_enabled, true, `server must be in hosted mode:\n${log}`);
-        break;
-      }
-    } catch {
-      /* not listening yet */
-    }
-    if (Date.now() > deadline) throw new Error(`server never became ready:\n${log}`);
-    await new Promise((r) => setTimeout(r, 100));
-  }
-
-  return { port, child, log: () => log };
-}
-
-function mcpFetch(port, { token, sessionId, body, method = "POST" }) {
-  const headers = {
-    accept: "application/json, text/event-stream",
-    "content-type": "application/json",
-  };
-  if (token) headers.authorization = `Bearer ${token}`;
-  if (sessionId) headers["mcp-session-id"] = sessionId;
-  return fetch(`http://127.0.0.1:${port}/mcp`, {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  });
-}
-
-const INITIALIZE = {
-  jsonrpc: "2.0",
-  id: 1,
-  method: "initialize",
-  params: {
-    protocolVersion: "2025-06-18",
-    capabilities: {},
-    clientInfo: { name: "ownership-test", version: "1.0.0" },
-  },
-};
-
-/** Runs initialize + notifications/initialized and returns the issued session id. */
-async function openSession(port, token) {
-  const res = await mcpFetch(port, { token, body: INITIALIZE });
-  const text = await res.text(); // drain the SSE stream so the connection is released
-  assert.equal(res.status, 200, `initialize failed: ${text}`);
-  const sessionId = res.headers.get("mcp-session-id");
-  assert.ok(sessionId, "server did not issue an mcp-session-id");
-
-  const ack = await mcpFetch(port, {
-    token,
-    sessionId,
-    body: { jsonrpc: "2.0", method: "notifications/initialized" },
-  });
-  await ack.text();
-  return sessionId;
-}
+import {
+  startFakePropelAuth,
+  startMcpServer,
+  mcpFetch,
+  openSession,
+} from "./helpers/hostedMcpServer.js";
 
 test("hosted mode binds MCP sessions to the authenticated caller", async (t) => {
   const propelAuth = await startFakePropelAuth();
-  const mcp = await startMcpServer(propelAuth.address().port);
+  const mcp = await startMcpServer({ propelAuthPort: propelAuth.port });
 
   t.after(async () => {
-    mcp.child.kill();
-    await new Promise((r) => propelAuth.close(r));
+    mcp.close();
+    await propelAuth.close();
   });
 
   const { port } = mcp;

--- a/test/httpSessionOwnership.test.js
+++ b/test/httpSessionOwnership.test.js
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Two tenants of the same PropelAuth instance, each with their own Repliers key.
+const USERS = {
+  "alice-token": { sub: "user-alice", email: "alice@example.test", key: "KEY-ALICE" },
+  "bob-token": { sub: "user-bob", email: "bob@example.test", key: "KEY-BOB" },
+};
+
+/** Stand-in for PropelAuth: /oauth/userinfo + the backend user API mcpServer.js reads metadata from. */
+function startFakePropelAuth() {
+  const server = http.createServer((req, res) => {
+    const bearer = (req.headers.authorization || "").replace(/^Bearer /, "");
+    const url = new URL(req.url, "http://localhost");
+
+    if (url.pathname === "/oauth/userinfo") {
+      const user = USERS[bearer];
+      if (!user) return res.writeHead(401).end("{}");
+      return res
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ sub: user.sub, email: user.email, email_verified: true }));
+    }
+
+    const backend = url.pathname.match(/^\/api\/backend\/v1\/user\/(.+)$/);
+    if (backend) {
+      const user = Object.values(USERS).find((u) => u.sub === backend[1]);
+      if (!user) return res.writeHead(404).end("{}");
+      return res
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ metadata: { repliers_api_key: user.key } }));
+    }
+
+    res.writeHead(404).end("{}");
+  });
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+
+function freePort() {
+  return new Promise((resolve) => {
+    const probe = http.createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Boots the real mcpServer.js in hosted mode.
+ * REPLIERS_API_KEY='' matters: process.loadEnvFile never overrides an already-set
+ * variable, so the empty string keeps the repo's own .env from flipping the server
+ * into self-hosted mode (which would bypass verifyOAuthToken entirely).
+ */
+async function startMcpServer(propelAuthPort) {
+  const port = await freePort();
+  const oauthBase = `http://127.0.0.1:${propelAuthPort}`;
+  const child = spawn(process.execPath, ["mcpServer.js", "--http"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      REPLIERS_API_KEY: "",
+      PORT: String(port),
+      OAUTH_BASE_URL: oauthBase,
+      OAUTH_USERINFO_ENDPOINT: `${oauthBase}/oauth/userinfo`,
+      PROPELAUTH_API_KEY: "propelauth-test-key",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let log = "";
+  child.stdout.on("data", (d) => (log += d));
+  child.stderr.on("data", (d) => (log += d));
+
+  const deadline = Date.now() + 20000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`server exited early:\n${log}`);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      if (res.ok) {
+        const body = await res.json();
+        assert.equal(body.oauth_enabled, true, `server must be in hosted mode:\n${log}`);
+        break;
+      }
+    } catch {
+      /* not listening yet */
+    }
+    if (Date.now() > deadline) throw new Error(`server never became ready:\n${log}`);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  return { port, child, log: () => log };
+}
+
+function mcpFetch(port, { token, sessionId, body, method = "POST" }) {
+  const headers = {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return fetch(`http://127.0.0.1:${port}/mcp`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+const INITIALIZE = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "ownership-test", version: "1.0.0" },
+  },
+};
+
+/** Runs initialize + notifications/initialized and returns the issued session id. */
+async function openSession(port, token) {
+  const res = await mcpFetch(port, { token, body: INITIALIZE });
+  const text = await res.text(); // drain the SSE stream so the connection is released
+  assert.equal(res.status, 200, `initialize failed: ${text}`);
+  const sessionId = res.headers.get("mcp-session-id");
+  assert.ok(sessionId, "server did not issue an mcp-session-id");
+
+  const ack = await mcpFetch(port, {
+    token,
+    sessionId,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+  await ack.text();
+  return sessionId;
+}
+
+test("hosted mode binds MCP sessions to the authenticated caller", async (t) => {
+  const propelAuth = await startFakePropelAuth();
+  const mcp = await startMcpServer(propelAuth.address().port);
+
+  t.after(async () => {
+    mcp.child.kill();
+    await new Promise((r) => propelAuth.close(r));
+  });
+
+  const { port } = mcp;
+  const aliceSession = await openSession(port, "alice-token");
+
+  await t.test("rejects a foreign caller presenting another user's session id", async () => {
+    const res = await mcpFetch(port, {
+      token: "bob-token", // Bob's own valid token — he is authenticated, just not the owner
+      sessionId: aliceSession,
+      body: { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    });
+    const text = await res.text();
+    assert.equal(
+      res.status,
+      404,
+      `Bob rode Alice's session and would have used her Repliers key. Response: ${text}`
+    );
+  });
+
+  await t.test("still serves the session to its rightful owner", async () => {
+    const res = await mcpFetch(port, {
+      token: "alice-token",
+      sessionId: aliceSession,
+      body: { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
+    });
+    const text = await res.text();
+    assert.equal(res.status, 200, `owner was locked out of her own session: ${text}`);
+    assert.match(text, /Search_Listings/, `expected a tool roster, got: ${text}`);
+  });
+
+  await t.test("refuses to let a foreign caller terminate the session", async () => {
+    const attack = await mcpFetch(port, {
+      token: "bob-token",
+      sessionId: aliceSession,
+      method: "DELETE",
+    });
+    await attack.text();
+    assert.equal(attack.status, 404, "Bob was able to address Alice's session with DELETE");
+
+    const survivor = await mcpFetch(port, {
+      token: "alice-token",
+      sessionId: aliceSession,
+      body: { jsonrpc: "2.0", id: 4, method: "tools/list", params: {} },
+    });
+    await survivor.text();
+    assert.equal(survivor.status, 200, "Alice's session did not survive Bob's DELETE");
+  });
+
+  await t.test("rejects an unknown session id", async () => {
+    const res = await mcpFetch(port, {
+      token: "alice-token",
+      sessionId: "00000000-0000-4000-8000-000000000000",
+      body: { jsonrpc: "2.0", id: 5, method: "tools/list", params: {} },
+    });
+    await res.text();
+    assert.equal(res.status, 404);
+  });
+});


### PR DESCRIPTION
Security fix based on CVE
[In hosted (PropelAuth) mode, MCP session IDs are never bound to the authenticated caller — any user who obtains another user's mcp-session-id can hijack that session and act under the victim's Repliers API key](https://github.com/Repliers-io/mcp-server/security/advisories/GHSA-f6c5-f2ph-7x7p) reported by @SyedAnas01
